### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
     name: Source Code Security Scan (bandit)
     needs: audit-dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/AbhinavS99/GraphOrchestrator/security/code-scanning/3](https://github.com/AbhinavS99/GraphOrchestrator/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `scan-code-security` job. Since this job only runs a static analysis tool (`bandit`) and does not require any write permissions, we will set the permissions to `contents: read`. This ensures that the `GITHUB_TOKEN` has the minimal permissions required to execute the job.

The `permissions` block will be added directly under the `scan-code-security` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
