### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
     name: Dependency & Vulnerability Audit (pip-audit)
     needs: run-tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/AbhinavS99/GraphOrchestrator/security/code-scanning/2](https://github.com/AbhinavS99/GraphOrchestrator/security/code-scanning/2)

To fix the issue, add a `permissions` block to the `audit-dependencies` job. This block should specify the minimal permissions required for the job to function. Since the job only needs to read the repository's contents (e.g., `requirements.txt`), the `permissions` block should be set to `contents: read`. This change ensures that the job adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
