### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
     name: Run Unit Tests
     # needs: static-analysis  # <-- This makes sure it runs *after* static-analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/AbhinavS99/GraphOrchestrator/security/code-scanning/1](https://github.com/AbhinavS99/GraphOrchestrator/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `run-tests` job. Since the job only needs to read repository contents (e.g., to access the `requirements.txt` file and other source code), we will set `contents: read`. This ensures that the job has the minimum required permissions and does not inherit unnecessary write permissions from the repository.

The changes will be made in the `.github/workflows/ci.yml` file, specifically within the `run-tests` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
