### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cloc-report.yml
+++ b/.github/workflows/cloc-report.yml
@@ -3,6 +3,10 @@ name: Count Lines of Code (CLOC)
 on:
   workflow_dispatch:  # Allows manual trigger from GitHub UI
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   run-cloc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AbhinavS99/GraphOrchestrator/security/code-scanning/7](https://github.com/AbhinavS99/GraphOrchestrator/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. Based on the workflow's actions, it only needs `contents: read` to read the repository contents and `actions: write` to upload the artifact. These permissions will be set at the root of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
